### PR TITLE
Fixed a bug in getting the player's position.

### DIFF
--- a/components/ui/site.lua
+++ b/components/ui/site.lua
@@ -617,7 +617,7 @@ function UiSite.onAdd(site, player, event)
         true,
         surface.index,
         resource.resource_name,
-        Util.Naming.getSiteName({x = player.position[1], y = player.position[2]}, resource.resource_name)
+        Util.Naming.getSiteName({x = player.position.x, y = player.position.y}, resource.resource_name)
     )
 
     -- show this site in the menu


### PR DESCRIPTION
Fixes a bug in manual site creation

Error while running event dqol-resource-monitor::on_gui_click (ID 1)
dqol-resource-monitor/util/naming.lua:109: attempt to compare nil with number
stack traceback:
dqol-resource-monitor/util/naming.lua:109: in function 'posToCompassDirection'
dqol-resource-monitor/util/naming.lua:33: in function <dqol-resource-monitor/util/naming.lua:19>
(...tail calls...)
dqol-resource-monitor/components/ui/site.lua:620: in function '?'
dqol-resource-monitor/components/ui/ui.lua:100: in function <dqol-resource-monitor/components/ui/ui.lua:86>